### PR TITLE
Basic認証の設定定義

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,15 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
+
+  private
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,9 @@ set :default_env, {
   rbenv_root: "/usr/local/rbenv",
   path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
   AWS_ACCESS_KEY_ID: ENV["AWS_ACCESS_KEY_ID"],
-  AWS_SECRET_ACCESS_KEY: ENV["AWS_SECRET_ACCESS_KEY"]
+  AWS_SECRET_ACCESS_KEY: ENV["AWS_SECRET_ACCESS_KEY"],
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
 }
 
 # set :log_level, :debug

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,6 +5,8 @@
 
 
 server '18.176.176.29', user: 'ec2-user', roles: %w{app db web}
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
 


### PR DESCRIPTION
# What
 - application_controller.rbに本番環境の場合、Basic認証を行うbeforeアクションを定義
 - deploy.rbにBASIC_AUTH_USERとBASIC_AUTH_PASSWORDを明示的に環境変数を指定。
 - production.rbにunicornが現在の環境を本番環境として認識するように定義。

# Why
 - 本番環境のみでBasic認証を行うようにする。