### PR TITLE
電話番号確認ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/_registration.scss
+++ b/app/assets/stylesheets/_registration.scss
@@ -93,6 +93,9 @@
   width: 700px;
   margin: 0 auto;
   background: $white;
+  h2{
+    font-weight: bold;
+  }
 }
 .registration{
   font-size: 22px;

--- a/app/views/signup/phone_number.html.haml
+++ b/app/views/signup/phone_number.html.haml
@@ -33,9 +33,7 @@
           %button.btn-default.btn-red{type: "submit"} SMSを送信する
           %p ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
           .form-group.text-right
-            %a{href: "/", target: "_blank"}
-              電話番号の確認が必要な理由
-              %i.icon-arrow-right
+            = link_to "電話番号の確認が必要な理由", "/", target: "blank"
         %input{name: "__csrf_value", type: "hidden", value: ""}
         %input{name: "id", type: "hidden", value: ""}
 

--- a/app/views/signup/phone_number.html.haml
+++ b/app/views/signup/phone_number.html.haml
@@ -23,6 +23,21 @@
     %section.l-single-container
       %h2.registration.l-single-head
         電話番号の確認
+      %form.l-single-inner.registration-form{action: "http://localhost:3000/signup/sms_check", method: "GET"}
+        %input{name: "after_save_callback", type: "hidden", value: ""}
+        .l-single-content
+          .form-group
+            %label{for: "phone_number"} 携帯電話の番号
+            %input.input-default{name: "phone_number", placeholder: "携帯電話の番号を入力", type: "tel", value: ""}
+          %p 本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用して認証を行います。
+          %button.btn-default.btn-red{type: "submit"} SMSを送信する
+          %p ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
+          .form-group.text-right
+            %a{href: "/", target: "_blank"}
+              電話番号の確認が必要な理由
+              %i.icon-arrow-right
+        %input{name: "__csrf_value", type: "hidden", value: ""}
+        %input{name: "id", type: "hidden", value: ""}
 
   %footer.single-footer
     %nav.footernav


### PR DESCRIPTION
# what
 - 新規登録画面の電話番号確認ページのマークアップを実装
 - 実際の機能についてはハリボテの為、formタグやaタグを使ってます。
 - 機能周りはcontrollerの実装タイミングで修正予定

# why
 - 電話番号によるSMS二重認証を実施する為のページを用意する

# image
https://gyazo.com/04e2d8472bc004a0d5b1038bbdb1e513