### PR TITLE
二重認証ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/_registration.scss
+++ b/app/assets/stylesheets/_registration.scss
@@ -1,5 +1,5 @@
 .sign-container{
-  padding: 0 0 220px;
+  padding: 0 0 240px;
 }
 .sign-header{
   height: 128px;
@@ -86,9 +86,7 @@
 .after-del:after{
   display: none;
 }
-.single-main{
 
-}
 .l-single-container{
   width: 700px;
   margin: 0 auto;
@@ -188,6 +186,12 @@ label{
 }
 .text-center{
   text-align: center;
+}
+.registration-form{
+  a{
+    color: $blue;
+    text-decoration: none;
+  }
 }
 .l-single-inner.registration-form .form-group:not(:first-of-type), .l-single-inner.registration-form .btn-red {
   margin: 24px 0 0;

--- a/app/views/signup/sms_check.html.haml
+++ b/app/views/signup/sms_check.html.haml
@@ -23,6 +23,36 @@
     %section.l-single-container
       %h2.registration.l-single-head
         電話番号認証
+      %form.l-single-inner.registration-form{action: "http://localhost:3000/signup/address_input", method: "GET"}
+        %input{name: "after_save_callback", type: "hidden", value: ""}
+        .l-single-content
+          .form-group
+            %label{for: "phone_number"} 認証番号
+            %input.input-default{name: "phone_number", placeholder: "認証番号を入力", type: "tel", value: ""}
+          %p SMSで届いた認証番号を入力してください。
+          %button.btn-default.btn-red{type: "submit"} 認証して完了
+        %input{name: "__csrf_value", type: "hidden", value: ""}
+        %input{name: "id", type: "hidden", value: ""}
+
+      %form.l-single-inner.registration-form{action: "http://localhost:3000/signup/address_input", method: "GET"}
+        %input{name: "after_save_callback", type: "hidden", value: ""}
+        .l-single-content
+          .form-group
+            %label{for: "phone_number"} 30秒経っても認証番号が届かない方へ
+          %p 電話で認証番号を聞くこともできます。
+          %button.btn-default.btn-red{type: "submit"} 電話で認証番号を聞く（通話無料）
+        %input{name: "__csrf_value", type: "hidden", value: ""}
+        %input{name: "id", type: "hidden", value: ""}
+
+      .l-single-inner.registration-form
+        .l-single-content
+          %h3.l-chapter-sub-head 認証番号を再送することもできます。もう一度電話番号を入力して下さい。
+          %p
+            = link_to "電話番号を再度入力する", "/"
+          %p.l-single-text
+            ※SMSが届かない場合は
+            = link_to "SMS受信設定", "/", target: "_blank"
+            を確認して、もう一度電話番号を入力してください。
 
   %footer.single-footer
     %nav.footernav


### PR DESCRIPTION
# what
 - 二重認証ページのマークアップ を実装
 - マークアップ なのでform_withではなく一旦formタグを使っています
 - リンク先は一旦、絶対パスで指定しています。

# why
 - 二重認証で認証番号を取得するページを作成する為

# image
https://gyazo.com/aed3a7bdbff7de60cec47effd7d10a7c
https://gyazo.com/8fb89be6b0e2f6129ab2f9ad772a20e3