### PR TITLE
住所登録のマークアップ

### DIFF
--- a/app/assets/stylesheets/_registration.scss
+++ b/app/assets/stylesheets/_registration.scss
@@ -319,4 +319,33 @@ select{
   left: 15px;
   font-size: 20px;
 }
-
+.select-prefectures{
+  width: 378px;
+  height: 68px;
+  margin: 8px 0 0;
+  padding: 10px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: white;
+  line-height: 1.5;
+  font-size: 16px;
+}
+select {
+  -webkit-appearance: none;/* ベンダープレフィックス(Google Chrome、Safari用) */
+  -moz-appearance: none; /* ベンダープレフィックス(Firefox用) */
+  appearance: none; /* 標準のスタイルを無効にする */
+  cursor: pointer; /* マウスカーソルの形を指定する */
+  }
+  ::-ms-expand { /* select要素のデザインを無効にする（IE用） */
+  display: none;
+  }
+  .pulldown{
+    position: absolute;
+    right: -25px;
+    bottom: 15px;
+    font-size: 40px;
+    color: darkgray;
+  }
+  .posi-re{
+    position: relative;
+  }

--- a/app/views/signup/address_input.html.haml
+++ b/app/views/signup/address_input.html.haml
@@ -23,7 +23,46 @@
     %section.l-single-container
       %h2.registration.l-single-head
         住所入力
-
+      %form.l-single-inner.registration-form{action: "./howto_paiement", method: "GET", novalidate: "novalidate"}
+        %input{name: "__csrf_value", type: "hidden", value: "67518d6847f3b905e9498ac1234fb0f5561864925a2b3e8013af1d19c074fa641cae1af76f13c252e0f9428f35018324e873508ce4c48e667916dd951f4daac80"}/
+        .l-single-content
+          .form-group
+            %label お名前(全角)
+            %span.form-require 必須
+            %input.input-default{name: "family_name_kanji", placeholder: "例) 山田", type: "text", value: ""}
+            %input.input-default{name: "first_name_kanji", placeholder: "例) 彩", type: "text", value: ""}
+          .form-group
+            %label{for: "family_name_kanji"} お名前カナ(全角)
+            %span.form-require 必須
+            %input.input-default{name: "family_name_kana", placeholder: "例) ヤマダ", type: "text", value: ""}
+            %input.input-default{name: "first_name_kana", placeholder: "例) アヤ", type: "text", value: ""}
+          .form-group
+            %label{for: "post_number"} 郵便番号
+            %span.form-require 必須
+            %input.input-default{name: "post_number", placeholder: "例) 123-4567", type: "text", value: ""}
+          .form-group.posi-re
+            %label{for: "post_number"} 都道府県
+            %span.form-require 必須
+            = fa_icon 'chevron-down', class: "pulldown"
+            %select.select-prefectures{name: "prefectures"}
+              %option{value: ""} 北海道
+          %input{name: "login_type", type: "hidden", value: ""}
+          .form-group
+            %label{for: "city"} 市区町村
+            %span.form-require 必須
+            %input.input-default{name: "city", placeholder: "例）横浜市緑区", type: "text"}
+          .form-group
+            %label{for: "address"} 番地
+            %span.form-require 必須
+            %input.input-default{name: "address", placeholder: "例）青山１−１−１", type: "text"}
+          .form-group
+            %label{for: "after_address"} 建物名
+            %span 任意
+            %input.input-default{name: "after_address", placeholder: "例）柳ビル１０３", type: "text"}
+          .form-group
+            %label{for: "phone_number"} 電話
+            %span 任意
+            %input.input-default{name: "phone_number", placeholder: "例）09012345678", type: "text"}
   %footer.single-footer
     %nav.footernav
       %ul


### PR DESCRIPTION
# what
 - 住所登録ページのマークアップ を実装
 - プルダウンの中のデータは別ブランチでモデルに記述する形で実装予定
 - 実際の機能は別ブランチで実装予定

# why
 - ユーザーの住所を登録するページを用意する為

# image
https://gyazo.com/cf0c020045faf40f4efebdf3c6098d26
https://gyazo.com/174d95e46b75fc2adf0713da6200e2a6