### PR TITLE
やることリストのページ実装

### DIFF
--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -114,6 +114,16 @@
   .mypage-item-list li:last-child {
     border: 0;
   }
+  .mypage-item-not-found {
+    padding: 160px 0 60px;
+    background-image: url( "logo-gray-icon.svg");
+    background-repeat: no-repeat;
+    background-position: center 40px;
+    background-size: 78px 85px;
+    text-align: center;
+    font-size: 16px;
+    color: #ccc;
+}
   .mypage-go-list a {
     display: block;
     height: 56px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,9 @@ class UsersController < ApplicationController
   def notification
   end
 
+  def todo
+  end
+
   def set_user
     @user = User.find(1)
   end

--- a/app/views/users/_mypage-side.html.haml
+++ b/app/views/users/_mypage-side.html.haml
@@ -10,8 +10,8 @@
           = link_to 'お知らせ',user_notification_path(@user.id)
           = fa_icon "angle-right"
       %li
-        %a.mypage-nav-list-item
-          やることリスト
+        .mypage-nav-list-item
+          = link_to 'やることリスト', user_todo_path(@user.id)
           = fa_icon "angle-right"
       %li
         %a.mypage-nav-list-item

--- a/app/views/users/todo.html.haml
+++ b/app/views/users/todo.html.haml
@@ -1,0 +1,28 @@
+= render 'items/header'
+= render 'items/exhibit'
+%nav.bread-crumbs
+  %ul
+    %li
+      %span メルカリ
+      = fa_icon "angle-right"
+    %li
+      %span マイページ
+      = fa_icon "angle-right"
+    %li
+      %span やることリスト
+%main.mypage-container.clearfix
+  .mypage-content
+    %section.mypage-tab-container-notification-todo
+      %ul.mypage-tabs
+        %li
+          %h3
+            %a お知らせ
+        %li.active
+          %h3
+            %a やることリスト
+      .tab-content
+        %ul#mypage-tab-todo.mypage-item-list.tab-pane.active
+          %li.mypage-item-not-found.bold 現在、やることリストはありません
+
+  = render 'mypage-side'
+= render 'items/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :users do
     get 'method_of_payment'
     get 'notification'
+    get 'todo'
   end
   resources :signup do
     collection do


### PR DESCRIPTION
## WHY
マイページからやることリストのページに遷移できるようにしました。
## WHAT
マイページのCSSと同じなので微調整しました。
ヘッダーの下の部分が崩れてしまいましたがrenderでもってきている部分なのであとで編集します。
https://gyazo.com/0d84bce949848d2a56c11cc0278c22e2