### PR TITLE
pay.jpの導入

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require rails-ujs
+//= require jquery
+//= require jquery_ujs
 //= require activestorage
 //= require_tree .

--- a/app/assets/javascripts/cards.js
+++ b/app/assets/javascripts/cards.js
@@ -1,0 +1,34 @@
+$(function(){
+  var form = $("#card__form");
+  Payjp.setPublicKey("pk_test_a67978832759fd3d80de5451");
+  //まずはテスト鍵をセットする↑
+    $("#card__form").on("click", '#submit_btn', function(e){
+      e.preventDefault();
+    //↑ここでrailsの処理を止めることでjsの処理を行う
+      var card = {
+        number: $("#card_number").val(),
+        cvc: $("#card_cvc").val(),
+        exp_month: $("#card_month").val(),
+        exp_year: $("#card_year").val()
+      };
+     //↑Pay.jpに登録するデータを準備する
+      Payjp.createToken(card,function(status,response){
+     //↑先ほどのcard情報がトークンという暗号化したものとして返ってくる
+        form.find("input[type=submit]").prop("disabled", true);
+        if(status == 200){//←うまくいった場合200になるので
+          $("#card_number").removeAttr("name");
+          $("#card_cvc").removeAttr("name");
+          $("#card_month").removeAttr("name");
+          $("#card_year").removeAttr("name");
+         //↑このremoveAttr("name")はデータを保持しないように消している
+          var payjphtml = `<input type="hidden" name="payjpToken" value=${response.id}>`
+          form.append(payjphtml);
+          //↑これはdbにトークンを保存するのでjsで作ったトークンをセットしてる
+          $("#card__form").submit();
+         //↑そしてここでsubmit！！これでrailsのアクションにいく！もちろん上でトークンをセットしているのでparamsの中には{payjpToken="トークン"}という情報が入っている
+        }else{
+          alert("カード情報が正しくありません。");
+        }
+      });
+    });
+  });

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,0 +1,27 @@
+class CardsController < ApplicationController
+  def index
+  end
+
+ def create
+    @user_id = session[:id]
+    Payjp.api_key = "sk_test_1d1c3a9fc93711a1a4065fd5"
+    if params['payjpToken'].blank?
+      # paramsの中にjsで作った'payjpTokenが存在するか確かめる
+        redirect_to action: "index"
+    else
+        customer = Payjp::Customer.create(
+        card: params['payjpToken'],
+        )
+       # ↑ここでjay.jpに保存
+        @card = Card.new(user_id: @user_id, customer_id: customer.id, customer_card: customer.default_card)
+       # ここでdbに保存
+        if @card.save
+          redirect_to entry_done_signup_index_path
+          flash[:notice] = 'クレジットカードの登録が完了しました'
+        else
+          redirect_to action: "create"
+          flash[:alert] = 'クレジットカード登録に失敗しました'
+        end
+    end
+  end
+end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,6 +1,7 @@
 class SignupController < ApplicationController
+  # before_action :create, only: [:howto_paiement]
+
   def entry_start
-    # @user = User.new # 新規インスタンス作成
   end
 
   def member_infomation
@@ -30,10 +31,6 @@ class SignupController < ApplicationController
     @user = User.new # 新規インスタンス作成
   end
 
-  def howto_paiement
-    @user = User.new # 新規インスタンス作成
-  end
-
   def create
     @user = User.new(
       nickname: session[:nickname],
@@ -51,14 +48,15 @@ class SignupController < ApplicationController
 
     if @user.save
       session[:id] = @user.id
-      redirect_to entry_done_signup_index_path
+      flash[:notice] = 'ユーザー登録が完了しました'
+      redirect_to cards_path
     else
       redirect_to entry_start_signup_index_path
     end
-
   end
 
   def entry_done
+    sign_in User.find(session[:id]) unless user_signed_in?
   end
 
   private

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,0 +1,3 @@
+class Card < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :cards
 end

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -23,12 +23,12 @@
     %section.l-single-container
       %h2.registration.l-single-head
         支払い方法
-      = form_with model: @user, url: signup_index_path, class: "l-single-inner registration-form", local: true do |f|
+      = form_with url: cards_path, id: "card__form", class: "l-single-inner registration-form", local: true do |f|
         .l-single-content
           .form-group
             =f.label :card_number, 'カード番号'
             %span.form-require 必須
-            =f.text_field :card_number, class: "input-default", placeholder: "半角英数のみ"
+            =f.text_field :card_number, id: "card_number", class: "input-default", placeholder: "半角英数のみ"
           .credit-box.flex-box
             = image_tag('logo_visa.gif', class: 'credit')
             = image_tag('logo_mastercard.gif', class:'credit')
@@ -40,22 +40,22 @@
             =f.label '有効期限'
             %span.form-require 必須
             = fa_icon 'chevron-down', class: "pulldown-crd"
-            =f.select :expiration_month, [['1', "1"], ['2', "2"]], { include_blank: true, selected: 0}, {class: "select-prefectures"}
+            =f.select :exp_month, [['12', '12'], ['2', "2"]], { include_blank: true, selected: 0}, {class: "select-prefectures", id: "card_month"}
             %p.crd-fontmonth
               月
             = fa_icon 'chevron-down', class: "pulldown-crd2"
-            =f.select :expiration_month, [['19', "19"], ['20', "20"]], { include_blank: true, selected: 0}, {class: "select-prefectures second"}
+            =f.select :exp_year, [['2019', "2019"], ['2020', '2020']], { include_blank: true, selected: 0}, {class: "select-prefectures second", id: "card_year"}
             %p.crd-fontyear
               年
           .form-group
-            =f.label :sec_cord, 'セキュリティコード'
+            =f.label :card_cvc, 'セキュリティコード'
             %span.form-require 必須
-            =f.text_field :sec_cord, class: "input-default", placeholder: "カード背面４桁もしくは３桁の番号"
+            =f.text_field :card_cvc, id: "card_cvc", class: "input-default", placeholder: "カード背面４桁もしくは３桁の番号"
           .form-help.text-right
             = link_to("/", target: "_blank") do
               = fa_icon 'question-circle'
               本人情報の登録について
-          =f.submit "次へ進む", class: "btn-default btn-red"
+          =f.submit "次へ進む", class: "btn-default btn-red", id: "submit_btn"
 
   %footer.single-footer
     %nav.footernav

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,5 +7,6 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
+    %script{src: "https://js.pay.jp/", type: "text/javascript"}
   %body
     = yield

--- a/app/views/signup/address_input.html.haml
+++ b/app/views/signup/address_input.html.haml
@@ -23,7 +23,7 @@
     %section.l-single-container
       %h2.registration.l-single-head
         住所入力
-      = form_with model: @user, url: howto_paiement_signup_index_path, method: :get, class: "l-single-inner registration-form", local: true do |f|
+      = form_with model: @user, url: signup_index_path, class: "l-single-inner registration-form", local: true do |f|
         .l-single-content
           .form-group
             =f.label :family_name_kanji, 'お名前(全角)'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,8 @@ Rails.application.routes.draw do
       get 'phone_number'
       get 'sms_check' 
       get 'address_input'
-      get 'howto_paiement'
       get 'entry_done' 
     end
   end
+  resources :cards
 end

--- a/db/migrate/20191109035534_create_cards.rb
+++ b/db/migrate/20191109035534_create_cards.rb
@@ -1,0 +1,10 @@
+class CreateCards < ActiveRecord::Migration[5.2]
+  def change
+    create_table :cards do |t|
+      t.integer :user_id
+      t.string :customer_id
+      t.string :customer_card
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_07_145914) do
+ActiveRecord::Schema.define(version: 2019_11_09_035534) do
+
+  create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "customer_id"
+    t.string "customer_card"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"


### PR DESCRIPTION
# what
 - gem 'payjp'を利用したクレジットカード登録機能をサインアップページの中に導入。
 - payjpの情報を管理するコントローラーとサインアップ用のコントローラを分割。
 - 上記に伴い、クレジットカード登録ページのビューを変更
 - ユーザーIDとpayjpの情報を紐付けるテーブルを作成
 - payjpに情報を送信する為のjsファイルを作成
 - 機能実装に伴うルーティングの実装
 - サインアップ終了後にsessionに保存されているidで自動ログインする機能を実装

# why
 - サインアップの流れでクレジットカードの情報登録ができるようにする為
 - クレジットカードの情報を任意に呼び出して買い物をする機能実装の前準備の為