### PR TITLE
addressテーブルの実装

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -28,7 +28,8 @@ class SignupController < ApplicationController
   end
 
   def address_input
-    @user = User.new # 新規インスタンス作成
+    @user = User.new
+    @user.build_address
   end
 
   def create
@@ -43,9 +44,9 @@ class SignupController < ApplicationController
       first_name_kana: session[:first_name_kana],
       year: session[:year],
       month: session[:month],
-      day: session[:day]
+      day: session[:day],
+      address_attributes: set_params[:address_attributes]
     )
-
     if @user.save
       session[:id] = @user.id
       flash[:notice] = 'ユーザー登録が完了しました'
@@ -72,7 +73,8 @@ class SignupController < ApplicationController
       :first_name_kana,
       :year,
       :month,
-      :day
+      :day,
+      address_attributes:[:id, :post_code, :prefectures, :city, :address, :after_address, :phone_number]
     )
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :cards
+  has_one :address
+  accepts_nested_attributes_for :address
 end

--- a/app/views/signup/address_input.html.haml
+++ b/app/views/signup/address_input.html.haml
@@ -24,42 +24,43 @@
       %h2.registration.l-single-head
         住所入力
       = form_with model: @user, url: signup_index_path, class: "l-single-inner registration-form", local: true do |f|
-        .l-single-content
-          .form-group
-            =f.label :family_name_kanji, 'お名前(全角)'
-            %span.form-require 必須
-            =f.text_field :family_name_kanji, class: "input-default", placeholder: "例) 山田"
-            =f.text_field :first_name_kanji, class: "input-default", placeholder: "例) 彩"
-          .form-group
-            =f.label :family_name_kanji, 'お名前カナ(全角)'
-            %span.form-require 必須
-            =f.text_field :family_name_kana, class: "input-default", placeholder: "例) ヤマダ"
-            =f.text_field :first_name_kana, class: "input-default", placeholder: "例) アヤ"
-          .form-group
-            =f.label :post_code, '郵便番号'
-            %span.form-require 必須
-            =f.text_field :post_code, class: "input-default", placeholder: "例) 123-4567"
-          .form-group.posi-re
-            =f.label :post_number, '都道府県'
-            %span.form-require 必須
-            = fa_icon 'chevron-down', class: "pulldown"
-            =f.select :prefectures, [['北海道', ""],['沖縄', ""]], { include_blank: true, selected: 1}, {class: "prefectures-box"}
-          .form-group
-            =f.label :city, '市区町村'
-            %span.form-require 必須
-            =f.text_field :city, class: "input-default", placeholder: "例）横浜市緑区"
-          .form-group
-            =f.label :address, '番地'
-            %span.form-require 必須
-            =f.text_field :address, class: "input-default", placeholder: "例）青山１−１−１"
-          .form-group
-            =f.label :after_address, '建物名'
-            %span 任意
-            =f.text_field :after_address, class: "input-default", placeholder: "例）柳ビル１０３"
-          .form-group
-            =f.label :phone_number, '電話'
-            %span 任意
-            =f.text_field :phone_number, class: "input-default", placeholder: "例）09012345678"
+        = f.fields_for :address do |i|
+          .l-single-content
+            .form-group
+              =f.label :family_name_kanji, 'お名前(全角)'
+              %span.form-require 必須
+              =f.text_field :family_name_kanji, class: "input-default", placeholder: "例) 山田"
+              =f.text_field :first_name_kanji, class: "input-default", placeholder: "例) 彩"
+            .form-group
+              =f.label :family_name_kanji, 'お名前カナ(全角)'
+              %span.form-require 必須
+              =f.text_field :family_name_kana, class: "input-default", placeholder: "例) ヤマダ"
+              =f.text_field :first_name_kana, class: "input-default", placeholder: "例) アヤ"
+            .form-group
+              =i.label :post_code, '郵便番号'
+              %span.form-require 必須
+              =i.text_field :post_code, class: "input-default", placeholder: "例) 123-4567"
+            .form-group.posi-re
+              =i.label :post_number, '都道府県'
+              %span.form-require 必須
+              = fa_icon 'chevron-down', class: "pulldown"
+              =i.select :prefectures, [['北海道', "1"],['沖縄', "2"]], { include_blank: true, selected: 1}, {class: "prefectures-box"}
+            .form-group
+              =i.label :city, '市区町村'
+              %span.form-require 必須
+              =i.text_field :city, class: "input-default", placeholder: "例）横浜市緑区"
+            .form-group
+              =i.label :address, '番地'
+              %span.form-require 必須
+              =i.text_field :address, class: "input-default", placeholder: "例）青山１−１−１"
+            .form-group
+              =i.label :after_address, '建物名'
+              %span 任意
+              =i.text_field :after_address, class: "input-default", placeholder: "例）柳ビル１０３"
+            .form-group
+              =i.label :phone_number, '電話'
+              %span 任意
+              =i.text_field :phone_number, class: "input-default", placeholder: "例）09012345678"
           =f.submit "次へ進む", class: "btn-default btn-red"
   %footer.single-footer
     %nav.footernav

--- a/db/migrate/20191109080550_create_addresses.rb
+++ b/db/migrate/20191109080550_create_addresses.rb
@@ -1,0 +1,13 @@
+class CreateAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :addresses do |t|
+      t.string :post_code
+      t.integer :prefectures
+      t.string :city
+      t.string :address
+      t.string :after_address
+      t.string :phone_number
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191109084802_add_column_to_address.rb
+++ b/db/migrate/20191109084802_add_column_to_address.rb
@@ -1,0 +1,5 @@
+class AddColumnToAddress < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :addresses, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_09_035534) do
+ActiveRecord::Schema.define(version: 2019_11_09_084802) do
+
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "post_code"
+    t.integer "prefectures"
+    t.string "city"
+    t.string "address"
+    t.string "after_address"
+    t.string "phone_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
@@ -53,4 +66,5 @@ ActiveRecord::Schema.define(version: 2019_11_09_035534) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "addresses", "users"
 end


### PR DESCRIPTION
# what
 - addressテーブルを作成
 - userモデルとaddressモデルのアソシエーションを定義
 - 親モデルと子モデルを設定
 - address_inputにfields_forを記述

# why
 - ユーザー登録する際に、一緒に住所登録を行えるようにする為。
 - 住所とユーザー情報を紐づけて登録する為。