### PR TITLE
着払いと送料込み時の場合分け

### DIFF
--- a/app/views/items/purchase_page.html.haml
+++ b/app/views/items/purchase_page.html.haml
@@ -17,8 +17,12 @@
               .purchase_content__price__left
                 ¥
                 =@item.price
-              .purchase_content__price__right
-                送料込み
+              -if @item.expense == "送料込み（出品者負担）"
+                .purchase_content__price__right
+                  送料込み
+              -else
+                .purchase_content__price__right
+                  着払い
             .purchase_content__point
               .purchase_content__point__text
                 ポイントはありません

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -52,35 +52,39 @@
         .iteme_page_main__view_right__box_left
           商品の状態
         .iteme_page_main__view_right__box_right
-          新品、未使用
+          =@item.status
       .iteme_page_main__view_right__box.flex
         .iteme_page_main__view_right__box_left
           配送料の負担
         .iteme_page_main__view_right__box_right
-          送料込み
+          =@item.expense
       .iteme_page_main__view_right__box.flex
         .iteme_page_main__view_right__box_left
           配送の方法
         .iteme_page_main__view_right__box_right
-          ゆうメール
+          =@item.shipping_method
       .iteme_page_main__view_right__box.flex
         .iteme_page_main__view_right__box_left
           配送元地域
         .iteme_page_main__view_right__box_right
-          愛知県
+          =@item.prefecture
       .iteme_page_main__view_right__box.flex
         .iteme_page_main__view_right__box_left
           発送日の目安
         .iteme_page_main__view_right__box_right
-          １〜２日で発送
+          =@item.arrival_date
   .iteme_page_main__price
     .iteme_page_main__price__yen
       ¥
       = @item.price
     .iteme_page_main__price__tex
       （税込）
-    .iteme_page_main__price__postage
-      送料込み
+    -if @item.expense == "送料込み（出品者負担）"
+      .iteme_page_main__price__postage
+        送料込み
+    -else
+      .purchase_content__price__right
+        着払い
   .buy_btn
     =link_to item_purchase_page_path(@item),class: 'buy_btn' do
       購入画面に進む


### PR DESCRIPTION
# What
送料の負担状況によって表示を場合分け

# Why
着払いの商品に送料込みと間違った記述をしないため


＜着払い＞
https://gyazo.com/0c3326348437675602128f5283f83080
https://gyazo.com/8e498a0df37a8936939d866ab26fa272
＜送料込み＞
https://gyazo.com/dc94a8f743cf755e4a0d3f1ec143dbdc
https://gyazo.com/e23442b5dd428e1392382ab4070a21ff