### PR TITLE
address_inputのバリデーション実装

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -47,7 +47,11 @@ class SignupController < ApplicationController
       day: session[:day],
       address_attributes: set_params[:address_attributes]
     )
-    if @user.save
+    
+    if @user.invalid?
+      # binding.pry
+      render '/signup/address_input'
+    elsif @user.save
       session[:id] = @user.id
       flash[:notice] = 'ユーザー登録が完了しました'
       redirect_to cards_path

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,34 @@
 class Address < ApplicationRecord
   belongs_to :user
+  validate :post_vali
+  validates :prefectures, presence: true
+  validate :city_vali
+  validate :address_vali
+
+def address_vali
+  if address.blank?
+    errors.add(:address, :blank)
+  elsif address.match?(/1|2|3|4|5|6|7|8|9|0/)
+    errors.add(:address, :format)
+  end
+end
+
+def city_vali
+  if city.blank?
+    errors.add(:city, :blank)
+  elsif city.match?(/1|2|3|4|5|6|7|8|9|0/)
+    errors.add(:city, :format)
+  end
+end
+
+
+  VALID_POST = /\A\d{3}[-]\d{4}\z/
+  def post_vali
+    if post_code.blank?
+      errors.add(:post_code, :blank)
+    elsif !VALID_POST.match?(post_code)
+      errors.add(:post_code, :format)
+    end
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,8 +22,8 @@ class User < ApplicationRecord
   def fi_name_kana
     if first_name_kana.blank?
       errors.add(:first_name_kana, :blank)
-    # else !VALID_FIKANA_REGEX.match?(first_name_kana)
-    #   errors.add(:first_name_kana, :format)
+    elsif !VALID_FIKANA_REGEX.match?(first_name_kana)
+      errors.add(:first_name_kana, :format)
     end
   end
   
@@ -31,8 +31,8 @@ class User < ApplicationRecord
   def fi_name_kanji
     if first_name_kanji.blank?
       errors.add(:first_name_kanji, :blank)
-    # else !VALID_FIKANJI_REGEX.match?(first_name_kanji)
-    #   errors.add(:first_name_kanji, :format)
+    elsif !VALID_FIKANJI_REGEX.match?(first_name_kanji)
+      errors.add(:first_name_kanji, :format)
     end
   end
 
@@ -40,17 +40,16 @@ class User < ApplicationRecord
   def fa_name_kana
     if family_name_kana.blank?
       errors.add(:family_name_kana, :blank)
-    # else !VALID_FAKANA_REGEX.match?(family_name_kana)
-    #   errors.add(:family_name_kana, :format)
+    elsif !VALID_FAKANA_REGEX.match?(family_name_kana)
+      errors.add(:family_name_kana, :format)
     end
   end
 
-  VALID_FAKANJI_REGEX = /\A[ぁ-んァ-ン一-龥]/
   def fa_name_kanji
     if family_name_kanji.blank?
       errors.add(:family_name_kanji, :blank)
-    # else !VALID_FAKANJI_REGEX.match?(family_name_kanji)
-    #   errors.add(:family_name_kanji, :format)
+    elsif !VALID_FIKANJI_REGEX.match?(family_name_kanji)
+      errors.add(:family_name_kanji, :format)
     end
   end
 

--- a/app/views/signup/address_input.html.haml
+++ b/app/views/signup/address_input.html.haml
@@ -29,30 +29,34 @@
             .form-group
               =f.label :family_name_kanji, 'お名前(全角)'
               %span.form-require 必須
-              =f.text_field :family_name_kanji, class: "input-default", placeholder: "例) 山田"
-              =f.text_field :first_name_kanji, class: "input-default", placeholder: "例) 彩"
+              =f.text_field :family_name_kanji, class: "input-default", placeholder: "例) 山田", value: "#{session[:family_name_kanji]}"
+              =f.text_field :first_name_kanji, class: "input-default", placeholder: "例) 彩", value: "#{session[:first_name_kanji]}"
             .form-group
               =f.label :family_name_kanji, 'お名前カナ(全角)'
               %span.form-require 必須
-              =f.text_field :family_name_kana, class: "input-default", placeholder: "例) ヤマダ"
-              =f.text_field :first_name_kana, class: "input-default", placeholder: "例) アヤ"
+              =f.text_field :family_name_kana, class: "input-default", placeholder: "例) ヤマダ", value: "#{session[:family_name_kana]}"
+              =f.text_field :first_name_kana, class: "input-default", placeholder: "例) アヤ", value: "#{session[:first_name_kana]}"
             .form-group
               =i.label :post_code, '郵便番号'
               %span.form-require 必須
               =i.text_field :post_code, class: "input-default", placeholder: "例) 123-4567"
+              = render partial: 'shared/error-messages', locals: {user: @user.address, column: "post_code"}
             .form-group.posi-re
-              =i.label :post_number, '都道府県'
+              =i.label :prefectures, '都道府県'
               %span.form-require 必須
               = fa_icon 'chevron-down', class: "pulldown"
               =i.select :prefectures, [['北海道', "1"],['沖縄', "2"]], { include_blank: true, selected: 1}, {class: "prefectures-box"}
+              = render partial: 'shared/error-messages', locals: {user: @user.address, column: "prefectures"}
             .form-group
               =i.label :city, '市区町村'
               %span.form-require 必須
               =i.text_field :city, class: "input-default", placeholder: "例）横浜市緑区"
+              = render partial: 'shared/error-messages', locals: {user: @user.address, column: "city"}
             .form-group
               =i.label :address, '番地'
               %span.form-require 必須
               =i.text_field :address, class: "input-default", placeholder: "例）青山１−１−１"
+              = render partial: 'shared/error-messages', locals: {user: @user.address, column: "address"}
             .form-group
               =i.label :after_address, '建物名'
               %span 任意

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,11 @@
 ja:
   activerecord:
     attributes:
+      address:
+        post_code: ×
+        prefectures: ×
+        city: ×
+        address: ×
       user:
         nickname: ×
         email: ×
@@ -15,6 +20,14 @@ ja:
         day: ×日：
     errors:
       models:
+        address:
+          attributes:
+            address:
+              format: 全て全角で入力してください（数字含む）
+            city:
+              format: 全て全角で入力してください（数字含む）
+            post_code:
+              format: ハイフン付き半角数字７文字で入力してください
         user:
           attributes:
             email:


### PR DESCRIPTION
# what
 - 住所登録をする際に、必須項目の入力フォームにバリデーションを実装。
 - 郵便番号はハイフン付き半角数字７桁のみ入力可能
 - 住所の必須欄は半角数字は使用不可
 - 入力不備がある際はページ遷移しない
 - menber_infomationで入力された値はsessionに保持されているので消えない

# why
 - ユーザーが住所入力を正しくできるようにする為。

# image
https://gyazo.com/65ecb1a7a04b78f74f75575bc5264021