### PR TITLE
商品詳細user

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -63,7 +63,6 @@ before_action :set_purchase,  only:[:purchase_page]
 
   def show
     @category = Category.all
-    @user = User.all
   end 
 
   def purchase_page

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -63,6 +63,7 @@ before_action :set_purchase,  only:[:purchase_page]
 
   def show
     @category = Category.all
+    @user = User.all
   end 
 
   def purchase_page
@@ -78,7 +79,7 @@ before_action :set_purchase,  only:[:purchase_page]
   private
 
   def item_params
-    params.require(:item).permit( :name, :description, :price, :status, :prefecture, :expense, :category_id, :arrival_date, images_attributes:[:image_url])
+    params.require(:item).permit( :name, :description, :price, :status, :prefecture, :expense, :category_id,:seller_id, :arrival_date, images_attributes:[:image_url]).merge(seller_id: current_user.id)
   end
 
   def set_item

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   belongs_to :category
-  # belongs_to :seller, class_name: "User",:foreign_key => 'seller_id'
+   belongs_to :seller, class_name: "User",:foreign_key => 'seller_id'
   # belongs_to :buyer, class_name: "User",:foreign_key => 'buyer_id'
   accepts_nested_attributes_for :images
   validates :name, presence: true

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -22,7 +22,8 @@
         .iteme_page_main__view_right__box_left
           出品者
         .iteme_page_main__view_right__box_right
-          〇〇さん
+          =@item.seller.nickname
+          さん
           .item_page_faces.flex
             .item_page_face.flex
               .item_page_face__icon

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -136,7 +136,8 @@
         =fa_icon 'pinterest',class: 'items_icons__pinterest'
 .user_another_items
   .user_another_items__title
-    〇〇さんのその他の出品
+    =@item.seller.nickname
+    さんのその他の出品
   .user_another_item.clearfix.flex
     .user_another_item_boxs
       .item_list_box_item__image


### PR DESCRIPTION
#What
・class_nameを使い、出品した商品のseller_idにカレントユーザーのID
をデータベースに保存。
・出品詳細に出品したユーザーのnicknameを表示。

#Why
購入者に出品者が誰なのかを表示させるため。