### PR TITLE
Sold out機能

### DIFF
--- a/app/assets/stylesheets/items_show.scss
+++ b/app/assets/stylesheets/items_show.scss
@@ -105,6 +105,15 @@
   text-align: center;
   font-weight: 600;
 }
+.buy_btn2{
+  font-size: 24px;
+  line-height: 60px;
+  margin-top: 16px;
+  background: #888;
+  color: $white;
+  text-align: center;
+  font-weight: 600;
+}
 .item_buyer_comment{
   padding: 32px 0 0;
   line-height: 1.5;

--- a/app/assets/stylesheets/items_show.scss
+++ b/app/assets/stylesheets/items_show.scss
@@ -313,3 +313,23 @@
     font-weight: 600;
   }
 }
+
+.items-box_photo__sold{
+  width: 0;
+  height: 0;
+  border-top: 60px solid #ea352d ;
+  border-right: 60px solid transparent;
+  border-bottom: 60px solid transparent;
+  border-left: 60px solid #ea352d ;
+  z-index:100;
+  position: relative;
+  top:-320px;
+  &__inner{
+    transform: rotate(-45deg);
+    font-size: 20px;
+    margin:-15px 0px 0px -55px;
+    color: #fff;
+    letter-spacing: 2px;
+    font-weight: 600;
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -70,6 +70,7 @@ before_action :set_purchase,  only:[:purchase_page]
     Payjp.api_key = Rails.application.credentials.aws[:pay_secret_key]
     customer = Payjp::Customer.retrieve(card.customer_id)
     @default_card_information = customer.cards.retrieve(card.customer_card)
+    @item.update( buyer_id: current_user.id)
   end
 
   def images_up

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -2,6 +2,10 @@
   =link_to item_path(item) do
     .item_list_box_item__image
       = image_tag item.images[0].image_url.url
+      -if  item.buyer_id.present? 
+        .items-box_photo__sold
+          .items-box_photo__sold__inner
+            SOLD
       .image_price
         .image_price__enn
           ¥

--- a/app/views/items/purchase_page.html.haml
+++ b/app/views/items/purchase_page.html.haml
@@ -45,11 +45,15 @@
               配送先
             .purchase_address__content__bottom
               .purchase_address__content__top__num
-                〒000-000
+                〒
+                =  current_user.address.post_code
               .purchase_address__content__top__add
-                愛知県半田市○◯町0-0-0
+                =  current_user.address.prefecture.name
+                =  current_user.address.city
+                =  current_user.address.address
               .purchase_address__content__top__name
-                廣田亜由美
+                = current_user.family_name_kanji
+                = current_user.first_name_kanji
             .purchase_address__content__btn
               変更する ＞
         = render template: "cards/show"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -43,12 +43,7 @@
         .iteme_page_main__view_right__box_left
           カテゴリー
         .iteme_page_main__view_right__box_right
-          - id = @item.category_id
-          =@category[id].parent.parent.category_name
-          >
-          =@category[id].parent.category_name
-          >
-          =@category[id].category_name
+          レディース
       .iteme_page_main__view_right__box.flex
         .iteme_page_main__view_right__box_left
           ブランド
@@ -90,9 +85,13 @@
     -else
       .purchase_content__price__right
         着払い
-  .buy_btn
-    =link_to item_purchase_page_path(@item),class: 'buy_btn' do
-      購入画面に進む
+  -if @item.buyer_id.nil?
+    .buy_btn
+      =link_to item_purchase_page_path(@item),class: 'buy_btn' do
+        購入画面に進む
+  -else
+    .buy_btn2
+      売り切れました
   .edit_btn
     = link_to '商品の編集', edit_item_path(@item)
   .on_hold_btn


### PR DESCRIPTION
## WHAT
商品を購入時にbuyer_idを追加。
一覧からbuyer_idがNULLではない商品にSOLDのCSSを当てるようにしました。
商品詳細ページでbuyer_idがNULLではない商品は購入できないようにしました。
購入画面の購入者の個人情報をDBから表示するようにしました。
## WHY
なんども購入できてしまうのでできないようにしました。
一覧でSOLDOUTした商品が一目でわかるようにしました。
https://gyazo.com/45f53d46dbae32037762b9d77489dd45
https://gyazo.com/e8494745cd1ae319d41448b05d01f361
https://gyazo.com/60fea14807f4cbfd90318c3ea01f2df0