### PR TITLE
商品投稿ページの機能追加

### DIFF
--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -55,7 +55,6 @@ $(function(){
       $('#grandchildren_wrapper').remove();
     }
   });
-  console.log("This")
   ///子カテゴリー選択後
   $('.exhibit_box__list__category').on('change', '#child_category', function(){
     var childId = $('#child_category option:selected').data('category'); //選択された子カテゴリーのidを取得

--- a/app/assets/javascripts/images.js
+++ b/app/assets/javascripts/images.js
@@ -49,8 +49,6 @@ $(document).on('change', 'input[type="file"]', function(event){
     }
  var new_image = $(`<input multiple= "multiple" name="images[image_url][]" class="images_up_contents__up" data-image= ${images.length} type="file" id="upload-image">`);
  input_area.prepend(new_image);
-
-  
 });
 });
 

--- a/app/assets/javascripts/images.js
+++ b/app/assets/javascripts/images.js
@@ -1,12 +1,11 @@
-$(document).on('turbolinks:load', function(){
-  var dropzone = $('.dropzone-area');
-  var dropzone_box = $('.dropzone-box');
+$(function(){
+  var dropzone = $('.exhibit_main_pagging__date__content');
   var images = [];
   var inputs  =[];
   var input_area = $('.input_area');
   var preview = $('#preview');
 
-$(document).on('change', 'input[type= "file"].uplpad-image', function(event){
+$(document).on('change', 'input[type="file"]', function(event){
   var file = $(this).prop('files')[0];    //prop()でアップロードの状態を取得し変数に格納
   var reader = new FileReader();          //filereaderのインスタンス作成
   inputs.push($(this));                   //配列にfileをpush
@@ -26,6 +25,10 @@ $(document).on('change', 'input[type= "file"].uplpad-image', function(event){
     dropzone.css({
       'display': 'none'
     })
+    $.each(images, function(index, image) {
+      image.attr('data-image', index);
+      preview.append(image);
+    })
   } else {
       $('#preview').empty();
       $.each(images, function(index, image) {
@@ -33,17 +36,19 @@ $(document).on('change', 'input[type= "file"].uplpad-image', function(event){
         preview.append(image);
       })
       dropzone.css({
-        'width': `calc(100% - (135px * ${images.length}))`
+        'width': `calc(100% - (180px * ${images.length}))`
       })
     }
-    if(images.length == 4) {
+    if(images.length == 3) {
+      dropzone.css({
+        'font-size': `15px`
+      })
       dropzone.find('p').replaceWith('<i class="fa fa-camera"></i>')
-    
     return;
   
     }
  var new_image = $(`<input multiple= "multiple" name="images[image_url][]" class="images_up_contents__up" data-image= ${images.length} type="file" id="upload-image">`);
-  exhibit_main_pagging__date__image.prepend(new_image);
+ input_area.prepend(new_image);
 
   
 });

--- a/app/assets/stylesheets/images_up.scss
+++ b/app/assets/stylesheets/images_up.scss
@@ -1,23 +1,14 @@
 .images_up_contents{
   margin: 0 0 10px 10px;
-  // position: relative;
   display: inline-block;
-  // width: 18%;
-  // margin: 0 0 2% 2%;
-  // border: 1px solid #eee;
   vertical-align: top;
-  // width: 116px;
   img{
     width: 100px;
   }
-
   &__up{
-    // height: 114px;
-    // background: blue;
     display: none;
   }
   &__bottom{
-
     font-size: 14px;
     &__left{
       display: inline-block;

--- a/app/assets/stylesheets/images_up.scss
+++ b/app/assets/stylesheets/images_up.scss
@@ -1,16 +1,20 @@
 .images_up_contents{
   margin: 0 0 10px 10px;
-  position: relative;
+  // position: relative;
   display: inline-block;
-  width: 18%;
-  margin: 0 0 2% 2%;
-  border: 1px solid #eee;
+  // width: 18%;
+  // margin: 0 0 2% 2%;
+  // border: 1px solid #eee;
   vertical-align: top;
-  width: 116px;
+  // width: 116px;
+  img{
+    width: 100px;
+  }
 
   &__up{
-    height: 114px;
-    background: blue;
+    // height: 114px;
+    // background: blue;
+    display: none;
   }
   &__bottom{
 
@@ -34,6 +38,8 @@
     }
   }
 }
+.add-box{
+  vertical-align: top;
+}
 
-    
       

--- a/app/assets/stylesheets/new_exhibit.scss
+++ b/app/assets/stylesheets/new_exhibit.scss
@@ -20,7 +20,7 @@
   &__date{
     display: block;
     width: 620px;
-    margin: 16px auto 0;
+    margin: 0 auto;
     &__content{
     padding: 40px;
     margin-left: 0;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,6 @@ before_action :set_purchase,  only:[:purchase_page]
 
   def create
     @item = Item.new(item_params)
-    # binding.pry
     respond_to do |format|
       if @item.save
           params[:images][:image_url].each do |image|

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,20 +25,19 @@ before_action :set_purchase,  only:[:purchase_page]
 
   def create
     @item = Item.new(item_params)
-    
-    # respond_to do |format|
-    if @item.save
-      # params[:images][:image_url].each do |image|
-      #   @item.images.create(image_url: image, item_id: @item.id)
-      # end
-      # format.html{redirect_to item_exhibit_ok_path(@item)}
-      redirect_to item_exhibit_ok_path(@item)
-    else
-     
-      
-      # format.html{render action: :new}
-      render action: :new
-      
+    binding.pry
+    respond_to do |format|
+      if @item.save
+          params[:images][:image_url].each do |image|
+          @item.images.create(image_url: image, item_id: @item.id)
+          end
+        format.html{redirect_to item_exhibit_ok_path(@item)}
+        # redirect_to item_exhibit_ok_path(@item)
+      else
+      @item.images.build
+      format.html{render action: 'new'}
+        # render action: :new
+      end
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,18 +25,16 @@ before_action :set_purchase,  only:[:purchase_page]
 
   def create
     @item = Item.new(item_params)
-    binding.pry
+    # binding.pry
     respond_to do |format|
       if @item.save
           params[:images][:image_url].each do |image|
           @item.images.create(image_url: image, item_id: @item.id)
           end
         format.html{redirect_to item_exhibit_ok_path(@item)}
-        # redirect_to item_exhibit_ok_path(@item)
       else
       @item.images.build
       format.html{render action: 'new'}
-        # render action: :new
       end
     end
   end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -19,10 +19,15 @@
           %label
             = f.fields_for :images, @item.images.build, local: true do |fin|
               .exhibit_main_pagging__date
-                .exhibit_main_pagging__date__image
+              #preview
                 .exhibit_main_pagging__date__content
+                  = fin.label :image_url, class: 'f_input_image', for:"upload-image" do
+                    = fin.file_field :image_url, class: 'f_input_image', multiple: true, name: 'images[image_url][]', 'data-image': 0
                   %p ドラッグアンドドロップまたはクリックしてファイルをアップロード
-                  = fin.file_field :image_url, class: 'f_input_image', type:"file" 
+              #preview2
+                .exhibit_main_pagging__date__content
+                  = fin.label :image_url, class: 'f_input_image', for:"upload-image" do
+                    %p ドラッグアンドドロップまたはクリックしてファイルをアップロード
         .exhibit_box
           .exhibit_box__name
             .form-group

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -16,18 +16,18 @@
               必須
           .exhibit_main_pagging__up
             最大5枚までアップロードできます
-          %label
-            = f.fields_for :images, @item.images.build, local: true do |fin|
-              .exhibit_main_pagging__date
-              #preview
-                .exhibit_main_pagging__date__content
-                  = fin.label :image_url, class: 'f_input_image', for:"upload-image" do
-                    = fin.file_field :image_url, class: 'f_input_image', multiple: true, name: 'images[image_url][]', 'data-image': 0
-                  %p ドラッグアンドドロップまたはクリックしてファイルをアップロード
-              #preview2
-                .exhibit_main_pagging__date__content
-                  = fin.label :image_url, class: 'f_input_image', for:"upload-image" do
-                    %p ドラッグアンドドロップまたはクリックしてファイルをアップロード
+          .add-box.flex
+            #preview.flex
+            .input_area
+            .add-wrap
+              %label
+                = f.fields_for :images, local: true do |fin|
+                  .exhibit_main_pagging__date
+                    .exhibit_main_pagging__date__content
+                      = fin.label :image_url, class: 'dropzone-box', for: "upload-image" do
+                        = fin.file_field :image_url, class: 'f_input_image upload-image', multiple: true, name: 'images[image_url][]', id: "upload-image"
+                      %p ドラッグアンドドロップまたはクリックしてファイルをアップロード
+
         .exhibit_box
           .exhibit_box__name
             .form-group


### PR DESCRIPTION
# what
 - 画像を５枚まで同時に投稿する機能を実装。
 - 画像のプレビューを５枚まで表示させる機能を実装。
 - 保存状況はDBを確認し、該当する商品IDと紐づいた状態で保存される事を確認。

# why
 - ユーザーが複数毎画像を投稿する為。
 - 投稿した画像がわかるようにする為。

# image
https://gyazo.com/a9d10a8f885cf23733077a95db064d24