### PR TITLE
商品詳細ページ画像切り替え

### DIFF
--- a/app/assets/javascripts/item_detaile.js
+++ b/app/assets/javascripts/item_detaile.js
@@ -1,0 +1,9 @@
+$(function() {
+  $('.item_show').on("mouseover", function() {
+    var ImgSrc = $(this).attr("src");
+    $("img#mainphoto").attr({src:ImgSrc});
+    $("img#mainphoto").hide();
+    $("img#mainphoto").fadeIn();
+        return false;
+    });
+  });

--- a/app/assets/stylesheets/items_show.scss
+++ b/app/assets/stylesheets/items_show.scss
@@ -57,11 +57,9 @@
 }
 
 .iteme_page_main__view_left_imagess{
-  &__image{
+  img {
     width: 60px;
     height: 60px;
-    max-height: none;
-    background: pink;
   }
 }
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,6 +58,7 @@ before_action :add_buy, only:[:purchase_pay]
   end
 
   def show
+    @images = @item.images
     @category = Category.all
     @user_items= Item.where(seller_id: @item.seller.id).order("created_at DESC").page(params[:item]).per(6)
   end 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,11 +5,11 @@
   .iteme_page_main__view.clearfix
     .iteme_page_main__view_left
       .iteme_page_main__view_left_image
-        = image_tag @item.images[0].image_url.url
+        = image_tag @item.images[0].image_url.url,class:"details__photo__main__image",id:"mainphoto"
       .iteme_page_main__view_left_imagess.flex
         .iteme_page_main__view_left_imagess__image
         - @images.each_with_index do |image, index|
-          = image_tag @images[index].image_url.url
+          = image_tag @images[index].image_url.url, class:"item_show"
     .iteme_page_main__view_right.clearfix
       .iteme_page_main__view_right__box.flex
         .iteme_page_main__view_right__box_left

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,15 +8,8 @@
         = image_tag @item.images[0].image_url.url
       .iteme_page_main__view_left_imagess.flex
         .iteme_page_main__view_left_imagess__image
-          1
-        .iteme_page_main__view_left_imagess__image
-          2
-        .iteme_page_main__view_left_imagess__image
-          3
-        .iteme_page_main__view_left_imagess__image
-          4
-        .iteme_page_main__view_left_imagess__image
-          5
+        - @images.each_with_index do |image, index|
+          = image_tag @images[index].image_url.url
     .iteme_page_main__view_right.clearfix
       .iteme_page_main__view_right__box.flex
         .iteme_page_main__view_right__box_left


### PR DESCRIPTION
## WHAT
商品詳細ページで保存された５枚の画像が表示するようにしました。
JSマウスオーバーで画像の切り替えがするようにしました。
https://gyazo.com/a553ce4cdb4297ec6887797177eeff6a